### PR TITLE
Feature/43 evaluate during training

### DIFF
--- a/configs/csg/pbe_with_repl_base.yaml
+++ b/configs/csg/pbe_with_repl_base.yaml
@@ -8,6 +8,7 @@ options:
         resolution: 4
         n_evaluate_dataset: 30
         timeout_sec: 5
+        interval_iter: 3000
     large:
         n_pretrain_iteration: 156250
         n_train_iteration: 281250
@@ -17,6 +18,7 @@ options:
         resolution: 1
         n_evaluate_dataset: 30
         timeout_sec: 120
+        interval_iter: 50000
 
 device:
     type: torch.device

--- a/configs/csg/pbe_with_repl_evaluate_base.yaml
+++ b/configs/csg/pbe_with_repl_evaluate_base.yaml
@@ -33,12 +33,10 @@ main:
   workspace_dir: "output/workspace"
   input_dir: "@/output_dir"
   output_dir: "@/output_dir"
-  test_dataset: "@/test_dataset"
   valid_dataset: "@/valid_dataset"
   model: "@/model"
   synthesizer: "@/synthesizer"
   metrics: {}
-  main_metric: "generation"
   top_n: []
   device: "@/device"
   n_process: 4

--- a/configs/csg/pbe_with_repl_evaluate_base.yaml
+++ b/configs/csg/pbe_with_repl_evaluate_base.yaml
@@ -39,4 +39,4 @@ main:
   metrics: {}
   top_n: []
   device: "@/device"
-  n_process: 4
+  n_process: 2

--- a/configs/csg/pbe_with_repl_pretrain_base.yaml
+++ b/configs/csg/pbe_with_repl_pretrain_base.yaml
@@ -86,7 +86,10 @@ main:
   length:
     type: mlprogram.entrypoint.train.Iteration
     n: "@/option.n_pretrain_iteration"
-  interval:
+  evaluation_interval:
+    type: mlprogram.entrypoint.train.Iteration
+    n: 1000
+  snapshot_interval:
     type: mlprogram.entrypoint.train.Iteration
     n: 1000
   device: "@/device"

--- a/configs/csg/pbe_with_repl_pretrain_base.yaml
+++ b/configs/csg/pbe_with_repl_pretrain_base.yaml
@@ -79,16 +79,8 @@ main:
   model: "@/model"
   optimizer: "@/optimizer"
   loss: "@/loss_fn"
-  score:
-    type: torch.nn.Sequential
-    modules:
-      type: collections.OrderedDict
-      items:
-        - - "loss"
-          - type: mlprogram.nn.action_sequence.Accuracy
-        - - "pick"
-          - type: mlprogram.nn.Pick
-            key: "action_sequence_accuracy"
+  evaluate: null
+  metric: "none"
   collate: "@/collate_fn"
   batch_size: "@/batch_size"
   length:
@@ -97,5 +89,4 @@ main:
   interval:
     type: mlprogram.entrypoint.train.Iteration
     n: 1000
-  n_model: 0
   device: "@/device"

--- a/configs/csg/pbe_with_repl_train_base.yaml
+++ b/configs/csg/pbe_with_repl_train_base.yaml
@@ -124,7 +124,6 @@ main:
     synthesizer: "@/synthesizer"
     metrics: {}
     top_n: []
-    n_process: 2
   metric: "generation_rate"
   reward:
     type: mlprogram.metrics.transform
@@ -146,8 +145,11 @@ main:
   length:
     type: mlprogram.entrypoint.train.Iteration
     n: "@/option.n_train_iteration"
-  interval:
+  evaluation_interval:
     type: mlprogram.entrypoint.train.Iteration
     n: "@/option.interval_iter"
+  snapshot_interval:
+    type: mlprogram.entrypoint.train.Iteration
+    n: 1000
   use_pretrained_model: true
   device: "@/device"

--- a/configs/csg/pbe_with_repl_train_base.yaml
+++ b/configs/csg/pbe_with_repl_train_base.yaml
@@ -148,6 +148,6 @@ main:
     n: "@/option.n_train_iteration"
   interval:
     type: mlprogram.entrypoint.train.Iteration
-    n: 1000
+    n: "@/option.interval_iter"
   use_pretrained_model: true
   device: "@/device"

--- a/configs/csg/pbe_with_repl_train_base.yaml
+++ b/configs/csg/pbe_with_repl_train_base.yaml
@@ -124,7 +124,7 @@ main:
     synthesizer: "@/synthesizer"
     metrics: {}
     top_n: []
-    n_process: 4
+    n_process: 2
   metric: "generation_rate"
   reward:
     type: mlprogram.metrics.transform

--- a/configs/csg/pbe_with_repl_train_base.yaml
+++ b/configs/csg/pbe_with_repl_train_base.yaml
@@ -118,16 +118,26 @@ main:
   model: "@/model"
   optimizer: "@/optimizer"
   loss: "@/loss_fn"
-  score:
-    type: mlprogram.metrics.TestCaseResult
-    interpreter: "@/interpreter"
-    reference: true
-    metric:
-      type: mlprogram.metrics.Iou
+  evaluate:
+    type: mlprogram.entrypoint.EvaluateSynthesizer
+    dataset: "@/test_dataset"
+    synthesizer: "@/synthesizer"
+    metrics: {}
+    top_n: []
+    n_process: 4
+  metric: "generation_rate"
   reward:
-    type: mlprogram.utils.Threshold
-    threshold: 0.9
-    dtype: "float"
+    type: mlprogram.metrics.transform
+    metric:
+      type: mlprogram.metrics.TestCaseResult
+      interpreter: "@/interpreter"
+      reference: true
+      metric:
+        type: mlprogram.metrics.Iou
+    transform:
+      type: mlprogram.utils.Threshold
+      threshold: 0.9
+      dtype: "float"
   rollout_transform:
     type: mlprogram.utils.transform.RandomChoice
   collate: "@/collate_fn"

--- a/configs/csg/without_repl_base.yaml
+++ b/configs/csg/without_repl_base.yaml
@@ -7,6 +7,7 @@ options:
         resolution: 4
         n_evaluate_dataset: 30
         timeout_sec: 5
+        interval_iter: 5000
     large:
         n_pretrain_iteration: 437500
         train_max_object: 13
@@ -15,6 +16,7 @@ options:
         resolution: 1
         n_evaluate_dataset: 30
         timeout_sec: 120
+        interval_iter: 50000
 
 device:
     type: torch.device

--- a/configs/csg/without_repl_evaluate_base.yaml
+++ b/configs/csg/without_repl_evaluate_base.yaml
@@ -27,4 +27,4 @@ main:
   metrics: {}
   top_n: []
   device: "@/device"
-  n_process: 4
+  n_process: 2

--- a/configs/csg/without_repl_evaluate_base.yaml
+++ b/configs/csg/without_repl_evaluate_base.yaml
@@ -21,12 +21,10 @@ main:
   workspace_dir: "output/workspace"
   input_dir: "@/output_dir"
   output_dir: "@/output_dir"
-  test_dataset: "@/test_dataset"
   valid_dataset: "@/valid_dataset"
   model: "@/model"
   synthesizer: "@/synthesizer"
   metrics: {}
-  main_metric: "generation"
   top_n: []
   device: "@/device"
   n_process: 4

--- a/configs/csg/without_repl_train_base.yaml
+++ b/configs/csg/without_repl_train_base.yaml
@@ -62,7 +62,7 @@ main:
     synthesizer: "@/synthesizer"
     metrics: {}
     top_n: []
-    n_process: 4
+    n_process: 2
   metric: "generation_rate"
   maximize: True
   collate: "@/collate_fn"

--- a/configs/csg/without_repl_train_base.yaml
+++ b/configs/csg/without_repl_train_base.yaml
@@ -70,7 +70,10 @@ main:
   length:
     type: mlprogram.entrypoint.train.Iteration
     n: "@/option.n_pretrain_iteration"
-  interval:
+  evaluation_interval:
+    type: mlprogram.entrypoint.train.Iteration
+    n: "@/option.interval_iter"
+  snapshot_interval:
     type: mlprogram.entrypoint.train.Iteration
     n: "@/option.interval_iter"
   device: "@/device"

--- a/configs/csg/without_repl_train_base.yaml
+++ b/configs/csg/without_repl_train_base.yaml
@@ -72,5 +72,5 @@ main:
     n: "@/option.n_pretrain_iteration"
   interval:
     type: mlprogram.entrypoint.train.Iteration
-    n: 1000
+    n: "@/option.interval_iter"
   device: "@/device"

--- a/configs/csg/without_repl_train_base.yaml
+++ b/configs/csg/without_repl_train_base.yaml
@@ -56,16 +56,15 @@ main:
   model: "@/model"
   optimizer: "@/optimizer"
   loss: "@/loss_fn"
-  score:
-    type: torch.nn.Sequential
-    modules:
-      type: collections.OrderedDict
-      items:
-        - - "loss"
-          - type: mlprogram.nn.action_sequence.Accuracy
-        - - "pick"
-          - type: mlprogram.nn.Pick
-            key: "action_sequence_accuracy"
+  evaluate:
+    type: mlprogram.entrypoint.EvaluateSynthesizer
+    dataset: "@/test_dataset"
+    synthesizer: "@/synthesizer"
+    metrics: {}
+    top_n: []
+    n_process: 4
+  metric: "generation_rate"
+  maximize: True
   collate: "@/collate_fn"
   batch_size: "@/batch_size"
   length:
@@ -74,5 +73,4 @@ main:
   interval:
     type: mlprogram.entrypoint.train.Iteration
     n: 1000
-  n_model: 3
   device: "@/device"

--- a/configs/django/nl2code_base.yaml
+++ b/configs/django/nl2code_base.yaml
@@ -7,7 +7,6 @@ parse:
   type: mlprogram.datasets.django.Parse
   tokenize:
     type: mlprogram.datasets.django.TokenizeToken
-
 to_action_sequence:
   type: mlprogram.utils.Compose
   funcs:
@@ -18,6 +17,25 @@ to_action_sequence:
       - - "ast_to_action_sequence"
         - type: mlprogram.actions.AstToActionSequence
 
+normalize_dataset:
+  type: mlprogram.utils.transform.NormalizeGroundTruth
+  normalize:
+    type: mlprogram.utils.Sequence
+    funcs:
+      type: collections.OrderedDict
+      items:
+        - - parse
+          - "@/parse"
+        - - unparse
+          - type: mlprogram.languages.python.Unparse
+test_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.test"
+  transform: "@/normalize_dataset"
+valid_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.valid"
+  transform: "@/normalize_dataset"
 
 action_sequence_reader:
   type: mlprogram.nn.nl2code.ActionSequenceReader
@@ -26,6 +44,7 @@ action_sequence_reader:
   num_node_types: "@/encoder.action_sequence_encoder._node_type_encoder.vocab_size"
   node_type_embedding_size: 64
   embedding_size: 128
+
 model:
   type: torch.nn.Sequential
   modules:
@@ -118,3 +137,37 @@ collate:
     use_pad_sequence: true
     dim: 0
     padding_value: -1
+
+synthesizer:
+  type: mlprogram.synthesizers.BeamSearch
+  beam_size: 15
+  max_step_size: 100
+  sampler:
+    type: mlprogram.samplers.transform
+    sampler:
+      type: mlprogram.samplers.ActionSequenceSampler
+      encoder: "@/encoder.action_sequence_encoder"
+      get_token_type: null
+      is_subtype:
+        type: mlprogram.languages.python.IsSubtype
+      transform_input:
+        type: mlprogram.utils.transform.nl2code.TransformQuery
+        extract_query:
+          type: mlprogram.datasets.django.TokenizeQuery
+        word_encoder: "@/encoder.word_encoder"
+      transform_action_sequence:
+        type: mlprogram.utils.transform.nl2code.TransformActionSequence
+        action_sequence_encoder: "@/encoder.action_sequence_encoder"
+        train: false
+      collate: "@/collate"
+      module: "@/model"
+    transform:
+      type: mlprogram.languages.python.Unparse
+
+# Metrics
+metrics:
+  accuracy:
+    type: mlprogram.metrics.Accuracy
+  bleu:
+    type: mlprogram.metrics.python.Bleu
+

--- a/configs/django/nl2code_evaluate.yaml
+++ b/configs/django/nl2code_evaluate.yaml
@@ -39,4 +39,4 @@ main:
   top_n:
     - 1
   device: "@/device"
-  n_process: 4
+  n_process: 2

--- a/configs/django/nl2code_evaluate.yaml
+++ b/configs/django/nl2code_evaluate.yaml
@@ -7,27 +7,9 @@ device:
   index: 0
 
 output_dir: "output/output"
-normalize_dataset:
-  type: mlprogram.utils.transform.NormalizeGroundTruth
-  normalize:
-    type: mlprogram.utils.Sequence
-    funcs:
-      type: collections.OrderedDict
-      items:
-        - - parse
-          - "@/parse"
-        - - unparse
-          - type: mlprogram.languages.python.Unparse
+
 dataset:
   type: mlprogram.datasets.django.download
-test_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.test"
-  transform: "@/normalize_dataset"
-valid_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.valid"
-  transform: "@/normalize_dataset"
 
 encoder:
   word_encoder:
@@ -45,56 +27,15 @@ encoder:
         - "@/output_dir"
         - "action_sequence_encoder.pt"
 
-transform:
-  transform_input:
-    type: mlprogram.utils.transform.nl2code.TransformQuery
-    extract_query:
-      type: mlprogram.datasets.django.TokenizeQuery
-    word_encoder: "@/encoder.word_encoder"
-  transform_action_sequence:
-    type: mlprogram.utils.transform.nl2code.TransformActionSequence
-    action_sequence_encoder: "@/encoder.action_sequence_encoder"
-    train: false
-
-synthesizer:
-  type: mlprogram.synthesizers.BeamSearch
-  beam_size: 15
-  max_step_size: 100
-  sampler:
-    type: mlprogram.samplers.transform
-    sampler:
-      type: mlprogram.samplers.ActionSequenceSampler
-      encoder: "@/encoder.action_sequence_encoder"
-      get_token_type: null
-      is_subtype:
-        type: mlprogram.languages.python.IsSubtype
-      transform_input: "@/transform.transform_input"
-      transform_action_sequence: "@/transform.transform_action_sequence"
-      collate: "@/collate"
-      module: "@/model"
-    transform:
-      type: mlprogram.languages.python.Unparse
-
-# Metrics
-metrics:
-  accuracy:
-    type: mlprogram.metrics.Accuracy
-  bleu:
-    type: mlprogram.metrics.python.Bleu
-
 main:
   type: mlprogram.entrypoint.evaluate
   workspace_dir: "output/workspace"
   input_dir: "@/output_dir"
   output_dir: "@/output_dir"
-  test_dataset: "@/test_dataset"
   valid_dataset: "@/valid_dataset"
   model: "@/model"
   synthesizer: "@/synthesizer"
   metrics: "@/metrics"
-  main_metric:
-    - 1
-    - "bleu"
   top_n:
     - 1
   device: "@/device"

--- a/configs/django/nl2code_train.yaml
+++ b/configs/django/nl2code_train.yaml
@@ -111,7 +111,10 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 50
-  interval:
+  evaluation_interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
+  snapshot_interval:
     type: mlprogram.entrypoint.train.Epoch
     n: 10
   device: "@/device"

--- a/configs/django/nl2code_train.yaml
+++ b/configs/django/nl2code_train.yaml
@@ -87,16 +87,16 @@ main:
         - - "pick"
           - type: mlprogram.nn.Pick
             key: "action_sequence_loss"
-  score:
-    type: torch.nn.Sequential
-    modules: 
-      type: collections.OrderedDict
-      items:
-        - - "loss"
-          - type: mlprogram.nn.action_sequence.Accuracy
-        - - "pick"
-          - type: mlprogram.nn.Pick
-            key: "action_sequence_accuracy"
+  evaluate:
+    type: mlprogram.entrypoint.EvaluateSynthesizer
+    dataset: "@/test_dataset"
+    synthesizer: "@/synthesizer"
+    metrics: "@/metrics"
+    top_n:
+      - 1
+    n_process: 4
+  metric: "bleu@1"
+  maximize: True
   collate:
     type: mlprogram.utils.Compose
     funcs:
@@ -111,4 +111,7 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 50
+  interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
   device: "@/device"

--- a/configs/django/nl2code_train.yaml
+++ b/configs/django/nl2code_train.yaml
@@ -94,7 +94,7 @@ main:
     metrics: "@/metrics"
     top_n:
       - 1
-    n_process: 4
+    n_process: 2
   metric: "bleu@1"
   maximize: True
   collate:

--- a/configs/hearthstone/nl2code_base.yaml
+++ b/configs/hearthstone/nl2code_base.yaml
@@ -17,6 +17,26 @@ to_action_sequence:
       - - "ast_to_action_sequence"
         - type: mlprogram.actions.AstToActionSequence
 
+normalize_dataset:
+  type: mlprogram.utils.transform.NormalizeGroundTruth
+  normalize:
+    type: mlprogram.utils.Sequence
+    funcs:
+      type: collections.OrderedDict
+      items:
+        - - parse
+          - "@/parse"
+        - - unparse
+          - type: mlprogram.languages.python.Unparse
+test_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.test"
+  transform: "@/normalize_dataset"
+valid_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.valid"
+  transform: "@/normalize_dataset"
+
 action_sequence_reader:
   type: mlprogram.nn.nl2code.ActionSequenceReader
   num_rules: "@/encoder.action_sequence_encoder._rule_encoder.vocab_size"
@@ -117,3 +137,34 @@ collate:
     dim: 0
     padding_value: -1
 
+synthesizer:
+  type: mlprogram.synthesizers.BeamSearch
+  beam_size: 15
+  max_step_size: 350
+  sampler:
+    type: mlprogram.samplers.transform
+    sampler:
+      type: mlprogram.samplers.ActionSequenceSampler
+      encoder: "@/encoder.action_sequence_encoder"
+      get_token_type: null
+      is_subtype:
+        type: mlprogram.languages.python.IsSubtype
+      transform_input:
+        type: mlprogram.utils.transform.nl2code.TransformQuery
+        extract_query:
+          type: mlprogram.datasets.hearthstone.TokenizeQuery
+        word_encoder: "@/encoder.word_encoder"
+      transform_action_sequence:
+        type: mlprogram.utils.transform.nl2code.TransformActionSequence
+        action_sequence_encoder: "@/encoder.action_sequence_encoder"
+        train: false
+      collate: "@/collate"
+      module: "@/model"
+    transform:
+      type: mlprogram.languages.python.Unparse
+
+metrics:
+  accuracy:
+    type: mlprogram.metrics.Accuracy
+  bleu:
+    type: mlprogram.metrics.python.Bleu

--- a/configs/hearthstone/nl2code_evaluate.yaml
+++ b/configs/hearthstone/nl2code_evaluate.yaml
@@ -8,27 +8,8 @@ device:
 
 output_dir: "output/output"
 
-normalize_dataset:
-  type: mlprogram.utils.transform.NormalizeGroundTruth
-  normalize:
-    type: mlprogram.utils.Sequence
-    funcs:
-      type: collections.OrderedDict
-      items:
-        - - parse
-          - "@/parse"
-        - - unparse
-          - type: mlprogram.languages.python.Unparse
 dataset:
   type: mlprogram.datasets.hearthstone.download
-test_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.test"
-  transform: "@/normalize_dataset"
-valid_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.valid"
-  transform: "@/normalize_dataset"
 
 encoder:
   word_encoder:
@@ -46,56 +27,15 @@ encoder:
         - "@/output_dir"
         - "action_sequence_encoder.pt"
 
-transform:
-  transform_input:
-    type: mlprogram.utils.transform.nl2code.TransformQuery
-    extract_query:
-      type: mlprogram.datasets.hearthstone.TokenizeQuery
-    word_encoder: "@/encoder.word_encoder"
-  transform_action_sequence:
-    type: mlprogram.utils.transform.nl2code.TransformActionSequence
-    action_sequence_encoder: "@/encoder.action_sequence_encoder"
-    train: false
-
-synthesizer:
-  type: mlprogram.synthesizers.BeamSearch
-  beam_size: 15
-  max_step_size: 350
-  sampler:
-    type: mlprogram.samplers.transform
-    sampler:
-      type: mlprogram.samplers.ActionSequenceSampler
-      encoder: "@/encoder.action_sequence_encoder"
-      get_token_type: null
-      is_subtype:
-        type: mlprogram.languages.python.IsSubtype
-      transform_input: "@/transform.transform_input"
-      transform_action_sequence: "@/transform.transform_action_sequence"
-      collate: "@/collate"
-      module: "@/model"
-    transform:
-      type: mlprogram.languages.python.Unparse
-
-# Metrics
-metrics:
-  accuracy:
-    type: mlprogram.metrics.Accuracy
-  bleu:
-    type: mlprogram.metrics.python.Bleu
-
 main:
   type: mlprogram.entrypoint.evaluate
   workspace_dir: "output/workspace"
   input_dir: "@/output_dir"
   output_dir: "@/output_dir"
-  test_dataset: "@/test_dataset"
   valid_dataset: "@/valid_dataset"
   model: "@/model"
   synthesizer: "@/synthesizer"
   metrics: "@/metrics"
-  main_metric:
-    - 1
-    - "bleu"
   top_n:
     - 1
   device: "@/device"

--- a/configs/hearthstone/nl2code_evaluate.yaml
+++ b/configs/hearthstone/nl2code_evaluate.yaml
@@ -39,4 +39,4 @@ main:
   top_n:
     - 1
   device: "@/device"
-  n_process: 4
+  n_process: 2

--- a/configs/hearthstone/nl2code_train.yaml
+++ b/configs/hearthstone/nl2code_train.yaml
@@ -111,7 +111,10 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 50
-  interval:
+  evaluation_interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
+  snapshot_interval:
     type: mlprogram.entrypoint.train.Epoch
     n: 10
   device: "@/device"

--- a/configs/hearthstone/nl2code_train.yaml
+++ b/configs/hearthstone/nl2code_train.yaml
@@ -87,16 +87,16 @@ main:
         - - "pick"
           - type: mlprogram.nn.Pick
             key: "action_sequence_loss"
-  score:
-    type: torch.nn.Sequential
-    modules:
-      type: collections.OrderedDict
-      items:
-        - - "loss"
-          - type: mlprogram.nn.action_sequence.Accuracy
-        - - "pick"
-          - type: mlprogram.nn.Pick
-            key: "action_sequence_accuracy"
+  evaluate:
+    type: mlprogram.entrypoint.EvaluateSynthesizer
+    dataset: "@/test_dataset"
+    synthesizer: "@/synthesizer"
+    metrics: "@/metrics"
+    top_n:
+      - 1
+    n_process: 4
+  metric: "bleu@1"
+  maximize: True
   collate:
     type: mlprogram.utils.Compose
     funcs:
@@ -111,4 +111,7 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 50
+  interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
   device: "@/device"

--- a/configs/hearthstone/nl2code_train.yaml
+++ b/configs/hearthstone/nl2code_train.yaml
@@ -94,7 +94,7 @@ main:
     metrics: "@/metrics"
     top_n:
       - 1
-    n_process: 4
+    n_process: 2
   metric: "bleu@1"
   maximize: True
   collate:

--- a/configs/hearthstone/treegen_base.yaml
+++ b/configs/hearthstone/treegen_base.yaml
@@ -17,6 +17,26 @@ to_action_sequence:
       - - "ast_to_action_sequence"
         - type: mlprogram.actions.AstToActionSequence
 
+normalize_dataset:
+  type: mlprogram.utils.transform.NormalizeGroundTruth
+  normalize:
+    type: mlprogram.utils.Sequence
+    funcs:
+      type: collections.OrderedDict
+      items:
+        - - parse
+          - "@/parse"
+        - - unparse
+          - type: mlprogram.languages.python.Unparse
+test_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.test"
+  transform: "@/normalize_dataset"
+valid_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.valid"
+  transform: "@/normalize_dataset"
+
 model:
   type: torch.nn.Sequential
   modules:
@@ -125,3 +145,40 @@ collate:
     use_pad_sequence: true
     dim: 0
     padding_value: -1
+
+synthesizer:
+  type: mlprogram.synthesizers.BeamSearch
+  beam_size: 15
+  max_step_size: 250
+  sampler:
+  sampler:
+    type: mlprogram.samplers.transform
+    sampler:
+      type: mlprogram.samplers.ActionSequenceSampler
+      encoder: "@/encoder.action_sequence_encoder"
+      get_token_type: null
+      is_subtype:
+        type: mlprogram.languages.python.IsSubtype
+      transform_input:
+        type: mlprogram.utils.transform.treegen.TransformQuery
+        extract_query:
+          type: mlprogram.datasets.hearthstone.TokenizeQuery
+        word_encoder: "@/encoder.word_encoder"
+        char_encoder: "@/encoder.char_encoder"
+        max_word_length: 128  
+      transform_action_sequence:
+        type: mlprogram.utils.transform.treegen.TransformActionSequence
+        action_sequence_encoder: "@/encoder.action_sequence_encoder"
+        max_arity: 128
+        max_depth: 128
+        train: false
+      collate: "@/collate"
+      module: "@/model"
+    transform:
+      type: mlprogram.languages.python.Unparse
+
+metrics:
+  accuracy:
+    type: mlprogram.metrics.Accuracy
+  bleu:
+    type: mlprogram.metrics.python.Bleu

--- a/configs/hearthstone/treegen_evaluate.yaml
+++ b/configs/hearthstone/treegen_evaluate.yaml
@@ -1,11 +1,6 @@
 imports:
 - "treegen_base.yaml"
 
-device:
-  type: torch.device
-  type_str: "cpu"
-  index: 0
-
 output_dir: "output/output"
 
 dataset:

--- a/configs/hearthstone/treegen_evaluate.yaml
+++ b/configs/hearthstone/treegen_evaluate.yaml
@@ -46,4 +46,4 @@ main:
   top_n:
     - 1
   device: "@/device"
-  n_process: 4
+  n_process: 2

--- a/configs/hearthstone/treegen_evaluate.yaml
+++ b/configs/hearthstone/treegen_evaluate.yaml
@@ -8,27 +8,8 @@ device:
 
 output_dir: "output/output"
 
-normalize_dataset:
-  type: mlprogram.utils.transform.NormalizeGroundTruth
-  normalize:
-    type: mlprogram.utils.Sequence
-    funcs:
-      type: collections.OrderedDict
-      items:
-        - - parse
-          - "@/parse"
-        - - unparse
-          - type: mlprogram.languages.python.Unparse
 dataset:
   type: mlprogram.datasets.hearthstone.download
-test_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.test"
-  transform: "@/normalize_dataset"
-valid_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.valid"
-  transform: "@/normalize_dataset"
 
 encoder:
   word_encoder:
@@ -53,61 +34,15 @@ encoder:
         - "@/output_dir"
         - "action_sequence_encoder.pt"
 
-transform:
-  transform_input:
-    type: mlprogram.utils.transform.treegen.TransformQuery
-    extract_query:
-      type: mlprogram.datasets.hearthstone.TokenizeQuery
-    word_encoder: "@/encoder.word_encoder"
-    char_encoder: "@/encoder.char_encoder"
-    max_word_length: 128
-  transform_action_sequence:
-    type: mlprogram.utils.transform.treegen.TransformActionSequence
-    action_sequence_encoder: "@/encoder.action_sequence_encoder"
-    max_arity: 128
-    max_depth: 128
-    train: false
-
-synthesizer:
-  type: mlprogram.synthesizers.BeamSearch
-  beam_size: 15
-  max_step_size: 250
-  sampler:
-  sampler:
-    type: mlprogram.samplers.transform
-    sampler:
-      type: mlprogram.samplers.ActionSequenceSampler
-      encoder: "@/encoder.action_sequence_encoder"
-      get_token_type: null
-      is_subtype:
-        type: mlprogram.languages.python.IsSubtype
-      transform_input: "@/transform.transform_input"
-      transform_action_sequence: "@/transform.transform_action_sequence"
-      collate: "@/collate"
-      module: "@/model"
-    transform:
-      type: mlprogram.languages.python.Unparse
-
-# Metrics
-metrics:
-  accuracy:
-    type: mlprogram.metrics.Accuracy
-  bleu:
-    type: mlprogram.metrics.python.Bleu
-
 main:
   type: mlprogram.entrypoint.evaluate
   workspace_dir: "output/workspace"
   input_dir: "@/output_dir"
   output_dir: "@/output_dir"
-  test_dataset: "@/test_dataset"
   valid_dataset: "@/valid_dataset"
   model: "@/model"
   synthesizer: "@/synthesizer"
   metrics: "@/metrics"
-  main_metric:
-    - 1
-    - "bleu"
   top_n:
     - 1
   device: "@/device"

--- a/configs/hearthstone/treegen_train.yaml
+++ b/configs/hearthstone/treegen_train.yaml
@@ -131,7 +131,10 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 25
-  interval:
+  evaluation_interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
+  snapshot_interval:
     type: mlprogram.entrypoint.train.Epoch
     n: 10
   device: "@/device"

--- a/configs/hearthstone/treegen_train.yaml
+++ b/configs/hearthstone/treegen_train.yaml
@@ -107,16 +107,16 @@ main:
         - - "pick"
           - type: mlprogram.nn.Pick
             key: "action_sequence_loss"
-  score:
-    type: torch.nn.Sequential
-    modules:
-      type: collections.OrderedDict
-      items:
-        - - "loss"
-          - type: mlprogram.nn.action_sequence.Accuracy
-        - - "pick"
-          - type: mlprogram.nn.Pick
-            key: "action_sequence_accuracy"
+  evaluate:
+    type: mlprogram.entrypoint.EvaluateSynthesizer
+    dataset: "@/test_dataset"
+    synthesizer: "@/synthesizer"
+    metrics: "@/metrics"
+    top_n:
+      - 1
+    n_process: 4
+  metric: "bleu@1"
+  maximize: True
   collate:
     type: mlprogram.utils.Compose
     funcs:
@@ -131,4 +131,7 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 25
+  interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
   device: "@/device"

--- a/configs/hearthstone/treegen_train.yaml
+++ b/configs/hearthstone/treegen_train.yaml
@@ -114,7 +114,7 @@ main:
     metrics: "@/metrics"
     top_n:
       - 1
-    n_process: 4
+    n_process: 2
   metric: "bleu@1"
   maximize: True
   collate:

--- a/configs/nl2bash/nl2code_base.yaml
+++ b/configs/nl2bash/nl2code_base.yaml
@@ -7,7 +7,6 @@ parse:
   type: mlprogram.languages.bash.Parse
   tokenize:
     type: mlprogram.languages.bash.TokenizeToken
-
 to_action_sequence:
   type: mlprogram.utils.Compose
   funcs:
@@ -18,6 +17,25 @@ to_action_sequence:
       - - "ast_to_action_sequence"
         - type: mlprogram.actions.AstToActionSequence
 
+normalize_dataset:
+  type: mlprogram.utils.transform.NormalizeGroundTruth
+  normalize:
+    type: mlprogram.utils.Sequence
+    funcs:
+      type: collections.OrderedDict
+      items:
+        - - parse
+          - "@/parse"
+        - - unparse
+          - type: mlprogram.languages.bash.Unparse
+test_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.test"
+  transform: "@/normalize_dataset"
+valid_dataset:
+  type: mlprogram.utils.data.transform
+  dataset: "@/dataset.valid"
+  transform: "@/normalize_dataset"
 
 action_sequence_reader:
   type: mlprogram.nn.nl2code.ActionSequenceReader
@@ -118,3 +136,35 @@ collate:
     use_pad_sequence: true
     dim: 0
     padding_value: -1
+
+synthesizer:
+  type: mlprogram.synthesizers.BeamSearch
+  beam_size: 15
+  max_step_size: 350
+  sampler:
+    type: mlprogram.samplers.transform
+    sampler:
+      type: mlprogram.samplers.ActionSequenceSampler
+      encoder: "@/encoder.action_sequence_encoder"
+      get_token_type: null
+      is_subtype:
+        type: mlprogram.languages.bash.IsSubtype
+      transform_input:
+        type: mlprogram.utils.transform.nl2code.TransformQuery
+        extract_query:
+          type: mlprogram.datasets.nl2bash.TokenizeQuery
+        word_encoder: "@/encoder.word_encoder"
+      transform_action_sequence:
+        type: mlprogram.utils.transform.nl2code.TransformActionSequence
+        action_sequence_encoder: "@/encoder.action_sequence_encoder"
+        train: false
+      collate: "@/collate"
+      module: "@/model"
+    transform:
+      type: mlprogram.languages.bash.Unparse
+
+metrics:
+  accuracy:
+    type: mlprogram.metrics.Accuracy
+  bleu:
+    type: mlprogram.metrics.Bleu

--- a/configs/nl2bash/nl2code_evaluate.yaml
+++ b/configs/nl2bash/nl2code_evaluate.yaml
@@ -8,27 +8,8 @@ device:
 
 output_dir: "output/output"
 
-normalize_dataset:
-  type: mlprogram.utils.transform.NormalizeGroundTruth
-  normalize:
-    type: mlprogram.utils.Sequence
-    funcs:
-      type: collections.OrderedDict
-      items:
-        - - parse
-          - "@/parse"
-        - - unparse
-          - type: mlprogram.languages.bash.Unparse
 dataset:
   type: mlprogram.datasets.nl2bash.download
-test_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.test"
-  transform: "@/normalize_dataset"
-valid_dataset:
-  type: mlprogram.utils.data.transform
-  dataset: "@/dataset.valid"
-  transform: "@/normalize_dataset"
 
 encoder:
   word_encoder:
@@ -46,57 +27,17 @@ encoder:
         - "@/output_dir"
         - "action_sequence_encoder.pt"
 
-transform:
-  transform_input:
-    type: mlprogram.utils.transform.nl2code.TransformQuery
-    extract_query:
-      type: mlprogram.datasets.nl2bash.TokenizeQuery
-    word_encoder: "@/encoder.word_encoder"
-  transform_action_sequence:
-    type: mlprogram.utils.transform.nl2code.TransformActionSequence
-    action_sequence_encoder: "@/encoder.action_sequence_encoder"
-    train: false
-
-synthesizer:
-  type: mlprogram.synthesizers.BeamSearch
-  beam_size: 15
-  max_step_size: 350
-  sampler:
-    type: mlprogram.samplers.transform
-    sampler:
-      type: mlprogram.samplers.ActionSequenceSampler
-      encoder: "@/encoder.action_sequence_encoder"
-      get_token_type: null
-      is_subtype:
-        type: mlprogram.languages.bash.IsSubtype
-      transform_input: "@/transform.transform_input"
-      transform_action_sequence: "@/transform.transform_action_sequence"
-      collate: "@/collate"
-      module: "@/model"
-    transform:
-      type: mlprogram.languages.bash.Unparse
-
-# Metrics
-metrics:
-  accuracy:
-    type: mlprogram.metrics.Accuracy
-  bleu:
-    type: mlprogram.metrics.Bleu
-
 main:
   type: mlprogram.entrypoint.evaluate
   workspace_dir: "output/workspace"
   input_dir: "@/output_dir"
   output_dir: "@/output_dir"
-  test_dataset: "@/test_dataset"
   valid_dataset: "@/valid_dataset"
   model: "@/model"
   synthesizer: "@/synthesizer"
   metrics: "@/metrics"
-  main_metric:
-    - 1
-    - "bleu"
   top_n:
     - 1
+    - 3
   device: "@/device"
   n_process: 4

--- a/configs/nl2bash/nl2code_evaluate.yaml
+++ b/configs/nl2bash/nl2code_evaluate.yaml
@@ -40,4 +40,4 @@ main:
     - 1
     - 3
   device: "@/device"
-  n_process: 4
+  n_process: 2

--- a/configs/nl2bash/nl2code_train.yaml
+++ b/configs/nl2bash/nl2code_train.yaml
@@ -87,16 +87,16 @@ main:
         - - "pick"
           - type: mlprogram.nn.Pick
             key: "action_sequence_loss"
-  score:
-    type: torch.nn.Sequential
-    modules:
-      type: collections.OrderedDict
-      items:
-        - - "loss"
-          - type: mlprogram.nn.action_sequence.Accuracy
-        - - "pick"
-          - type: mlprogram.nn.Pick
-            key: "action_sequence_accuracy"
+  evaluate:
+    type: mlprogram.entrypoint.evaluate
+    dataset: "@/test_dataset"
+    synthesizer: "@/synthesizer"
+    metrics: "@/metrics"
+    top_n:
+      - 1
+      - 3
+    n_process: 4
+  metric: "bleu@3"
   collate:
     type: mlprogram.utils.Compose
     funcs:
@@ -111,4 +111,7 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 50
+  interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
   device: "@/device"

--- a/configs/nl2bash/nl2code_train.yaml
+++ b/configs/nl2bash/nl2code_train.yaml
@@ -111,7 +111,10 @@ main:
   length:
     type: mlprogram.entrypoint.train.Epoch
     n: 50
-  interval:
+  evaluation_interval:
+    type: mlprogram.entrypoint.train.Epoch
+    n: 10
+  snapshot_interval:
     type: mlprogram.entrypoint.train.Epoch
     n: 10
   device: "@/device"

--- a/configs/nl2bash/nl2code_train.yaml
+++ b/configs/nl2bash/nl2code_train.yaml
@@ -95,7 +95,7 @@ main:
     top_n:
       - 1
       - 3
-    n_process: 4
+    n_process: 2
   metric: "bleu@3"
   collate:
     type: mlprogram.utils.Compose

--- a/mlprogram/entrypoint/__init__.py
+++ b/mlprogram/entrypoint/__init__.py
@@ -1,2 +1,3 @@
 from mlprogram.entrypoint.train import train_supervised, train_REINFORCE  # noqa
 from mlprogram.entrypoint.evaluate import evaluate  # noqa
+from mlprogram.entrypoint.evaluate import EvaluateSynthesizer  # noqa

--- a/mlprogram/entrypoint/__init__.py
+++ b/mlprogram/entrypoint/__init__.py
@@ -1,3 +1,4 @@
 from mlprogram.entrypoint.train import train_supervised, train_REINFORCE  # noqa
 from mlprogram.entrypoint.evaluate import evaluate  # noqa
+from mlprogram.entrypoint.evaluate import EvaluateSample  # noqa
 from mlprogram.entrypoint.evaluate import EvaluateSynthesizer  # noqa

--- a/mlprogram/entrypoint/evaluate.py
+++ b/mlprogram/entrypoint/evaluate.py
@@ -104,9 +104,8 @@ class EvaluateSynthesizer(Generic[Input, Code, GroundTruth]):
             for name in self.metrics.keys():
                 t[name] = 0.0
             total[n] = t
-        evaluate_sample = \
-            EvaluateSample[Dict[str, Any], Code](
-                self.synthesizer, self.metrics, self.top_n)
+        evaluate_sample: EvaluateSample[Dict[str, Any], Code] = \
+            EvaluateSample(self.synthesizer, self.metrics, self.top_n)
         inputs = []
         for group in self.dataset:
             for input in group["input"]:

--- a/mlprogram/entrypoint/evaluate.py
+++ b/mlprogram/entrypoint/evaluate.py
@@ -192,7 +192,7 @@ def evaluate(input_dir: str, workspace_dir: str, output_dir: str,
         logger.warning(f"There are multiple models in {model_dir}")
     pathes = []
     for model_path in os.listdir(model_dir):
-        model_path = os.path.join(model_dir, model_path)
+        model_path = os.path.join(model_dir, os.path.basename(model_path))
         score = \
             torch.load(model_path, map_location=torch.device("cpu"))["score"]
         pathes.append((score, model_path))
@@ -200,7 +200,6 @@ def evaluate(input_dir: str, workspace_dir: str, output_dir: str,
     model_path = pathes[0][1]
 
     logger.info(f"Start evaluation: {model_path}")
-    model_path = os.path.join(model_dir, model_path)
     state_dict = \
         torch.load(model_path, map_location=torch.device("cpu"))["model"]
     model.load_state_dict(state_dict)

--- a/mlprogram/entrypoint/evaluate.py
+++ b/mlprogram/entrypoint/evaluate.py
@@ -8,6 +8,7 @@ import torch
 from torch import nn
 import os
 import shutil
+from pytorch_pfn_extras.reporting import report
 from mlprogram.metrics import Metric
 from mlprogram.synthesizers import Synthesizer
 from mlprogram.utils.data import ListDataset
@@ -137,8 +138,14 @@ class EvaluateSynthesizer(Generic[Input, Code, GroundTruth]):
         total = {n: {name: value / len(inputs)
                      for name, value in metric.items()}
                  for n, metric in total.items()}
-        return EvaluationResult(results, total,
-                                np.mean(generated), np.mean(times))
+        r = EvaluationResult(results, total,
+                             np.mean(generated), np.mean(times))
+        for n, m in total.items():
+            for name, value in m.items():
+                report({f"{name}@{n}", value})
+        report("generation_rate", r.generation_rate)
+        report("generation_time", r.generation_time)
+        return r
 
 
 def evaluate(input_dir: str, workspace_dir: str, output_dir: str,

--- a/mlprogram/entrypoint/evaluate.py
+++ b/mlprogram/entrypoint/evaluate.py
@@ -150,11 +150,16 @@ class EvaluateSynthesizer(Generic[Input, Code, GroundTruth]):
                  for n, metric in total.items()}
         r = EvaluationResult(results, total,
                              np.mean(generated), np.mean(times))
+        # report
         for n, metric in total.items():
             for name, value in metric.items():
                 report({f"{name}@{n}": value})
         report({"generation_rate": r.generation_rate})
         report({"generation_time": r.generation_time})
+        # logging
+        logger.info(f"{r.metrics}")
+        logger.info(f"generation rate: {r.generation_rate}")
+        logger.info(f"generation time: {r.generation_time}")
         return r
 
 
@@ -194,17 +199,13 @@ def evaluate(input_dir: str, workspace_dir: str, output_dir: str,
     pathes.sort(key=lambda x: -x[0])
     model_path = pathes[0][1]
 
-    logger.info(f"Start evaluation (valid dataset): {model_path}")
+    logger.info(f"Start evaluation: {model_path}")
     model_path = os.path.join(model_dir, model_path)
     state_dict = \
         torch.load(model_path, map_location=torch.device("cpu"))["model"]
     model.load_state_dict(state_dict)
 
-    logger.info("Start evaluation using valid dataset")
     result = evaluate_synthesizer()
-    logger.info(f"{result.metrics}")
-    logger.info(f"generation rate: {result.generation_rate}")
-    logger.info(f"generation time: {result.generation_time}")
     torch.save(result, result_path)
 
     logger.info("Copy log to output_dir")

--- a/mlprogram/entrypoint/evaluate.py
+++ b/mlprogram/entrypoint/evaluate.py
@@ -82,9 +82,12 @@ class EvaluateSynthesizer(Generic[Input, Code, GroundTruth]):
     def __init__(self, dataset: torch.utils.data.Dataset,
                  synthesizer: Synthesizer[Dict[str, Any], Code],
                  metrics: Mapping[str, Metric], top_n: List[int] = [1, 3],
-                 n_process: Optional[int] = None):
+                 n_process: Optional[int] = None,
+                 n_samples: Optional[int] = None):
         super().__init__()
         self.dataset = dataset
+        if n_samples is not None:
+            self.dataset = ListDataset(self.dataset[:n_samples])
         self.synthesizer = synthesizer
         self.metrics = metrics
         self.top_n = top_n
@@ -160,14 +163,11 @@ def evaluate(input_dir: str, workspace_dir: str, output_dir: str,
         -> None:
     os.makedirs(workspace_dir, exist_ok=True)
 
-    if n_samples is not None:
-        valid_dataset = ListDataset(valid_dataset[:n_samples])
-
     logger.info("Prepare model")
     model.to(device)
 
     evaluate_synthesizer = EvaluateSynthesizer[Input, Code, GroundTruth](
-        valid_dataset, synthesizer, metrics, top_n, n_process)
+        valid_dataset, synthesizer, metrics, top_n, n_process, n_samples)
 
     # Move parameters to shared memory
     if n_process is not None:

--- a/mlprogram/entrypoint/train.py
+++ b/mlprogram/entrypoint/train.py
@@ -93,19 +93,18 @@ def create_extensions_manager(n_iter: int, interval_iter: int,
         manager.extend(extensions.LogReport(
             trigger=Trigger(interval_iter, n_iter)))
         manager.extend(extensions.ProgressBar())
+        if evaluate is not None:
+            manager.extend(Call(evaluate),
+                           trigger=Trigger(interval_iter, n_iter))
+        manager.extend(SaveTopKModel(model_dir, 1, metric, model,
+                                     maximize=maximize),
+                       trigger=Trigger(interval_iter, n_iter))
         manager.extend(extensions.PrintReport(entries=[
             "loss", metric,
             "iteration", "epoch",
             "time.iteration", "gpu.time.iteration", "elapsed_time"
         ]),
-            trigger=Trigger(interval_iter, n_iter))
-        if evaluate is not None:
-            manager.extend(Call(evaluate),
-                           trigger=Trigger(interval_iter, n_iter))
-
-        manager.extend(SaveTopKModel(model_dir, 1, metric, model,
-                                     maximize=maximize),
-                       trigger=Trigger(interval_iter, n_iter))
+            trigger=Trigger(100, n_iter))
     if distributed.is_initialized():
         snapshot = extensions.snapshot(autoload=True, n_retains=1,
                                        saver_rank=0)

--- a/mlprogram/entrypoint/train.py
+++ b/mlprogram/entrypoint/train.py
@@ -100,7 +100,7 @@ def create_extensions_manager(n_iter: int, interval_iter: int,
                                      maximize=maximize),
                        trigger=Trigger(interval_iter, n_iter))
         manager.extend(extensions.PrintReport(entries=[
-            "loss", metric,
+            "loss",
             "iteration", "epoch",
             "time.iteration", "gpu.time.iteration", "elapsed_time"
         ]),

--- a/mlprogram/entrypoint/train.py
+++ b/mlprogram/entrypoint/train.py
@@ -225,11 +225,7 @@ def train_supervised(workspace_dir: str, output_dir: str,
                     with logger.block("optimizer.step"):
                         optimizer.step()
 
-                    ppe.reporting.report({
-                        "loss": bloss.item(),
-                        "score": s.item()
-                    })
-                    logger.dump_eplased_time_log()
+                    logger.dump_elapsed_time_log()
                     if device.type == "cuda":
                         ppe.reporting.report({
                             "gpu.max_memory_allocated":
@@ -351,7 +347,7 @@ def train_REINFORCE(input_dir: str, workspace_dir: str, output_dir: str,
                         "loss": bloss.item(),
                         "score": np.mean(scores)
                     })
-                    logger.dump_eplased_time_log()
+                    logger.dump_elapsed_time_log()
                     if device.type == "cuda":
                         ppe.reporting.report({
                             "gpu.max_memory_allocated":

--- a/mlprogram/entrypoint/train.py
+++ b/mlprogram/entrypoint/train.py
@@ -91,7 +91,7 @@ def create_extensions_manager(n_iter: int, interval_iter: int,
     )
     if distributed.is_main_process():
         manager.extend(extensions.LogReport(
-            trigger=Trigger(interval_iter, n_iter)))
+            trigger=Trigger(100, n_iter)))
         manager.extend(extensions.ProgressBar())
         if evaluate is not None:
             manager.extend(Call(evaluate),

--- a/mlprogram/entrypoint/types.py
+++ b/mlprogram/entrypoint/types.py
@@ -88,6 +88,7 @@ types = {
     "mlprogram.datasets.nl2bash.TokenizeToken":
         mlprogram.datasets.nl2bash.TokenizeToken,
 
+    "mlprogram.metrics.transform": mlprogram.metrics.transform,
     "mlprogram.metrics.Accuracy": mlprogram.metrics.Accuracy,
     "mlprogram.metrics.Bleu": mlprogram.metrics.Bleu,
     "mlprogram.metrics.Iou": mlprogram.metrics.Iou,

--- a/mlprogram/entrypoint/types.py
+++ b/mlprogram/entrypoint/types.py
@@ -66,6 +66,8 @@ types = {
         mlprogram.entrypoint.train_supervised,
     "mlprogram.entrypoint.train_REINFORCE":
         mlprogram.entrypoint.train_REINFORCE,
+    "mlprogram.entrypoint.EvaluateSynthesizer":
+        mlprogram.entrypoint.EvaluateSynthesizer,
     "mlprogram.entrypoint.evaluate": mlprogram.entrypoint.evaluate,
 
     "mlprogram.datasets.django.download": mlprogram.datasets.django.download,

--- a/mlprogram/metrics/__init__.py
+++ b/mlprogram/metrics/__init__.py
@@ -1,4 +1,5 @@
 from mlprogram.metrics.metric import Metric  # noqa
+from mlprogram.metrics.metric import transform  # noqa
 from mlprogram.metrics.accuracy import Accuracy  # noqa
 from mlprogram.metrics.bleu import Bleu  # noqa
 from mlprogram.metrics.test_case_result import TestCaseResult  # noqa

--- a/mlprogram/metrics/metric.py
+++ b/mlprogram/metrics/metric.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Generic, TypeVar
+from typing import Dict, Any, Generic, TypeVar, Callable
 
 
 Value = TypeVar("Value")
@@ -7,3 +7,17 @@ Value = TypeVar("Value")
 class Metric(Generic[Value]):
     def __call__(self, input: Dict[str, Any], value: Value) -> float:
         raise NotImplementedError
+
+
+class TransformedMetric(Metric[Value], Generic[Value]):
+    def __init__(self, metric: Metric[Value], f: Callable[[float], float]):
+        super().__init__()
+        self.metric = metric
+        self.f = f
+
+    def __call__(self, input: Dict[str, Any], value: Value) -> float:
+        return self.f(self.metric(input, value))
+
+
+def transform(metric: Metric[Value], transform: Callable[[float], float]):
+    return TransformedMetric(metric, transform)

--- a/mlprogram/utils/logging.py
+++ b/mlprogram/utils/logging.py
@@ -25,7 +25,7 @@ class Logger(object):
         self.elapsed_time_log: Dict[str, Tuple[int, float]] = {}
         self.gpu_elapsed_time_log: Dict[str, Tuple[int, float]] = {}
 
-    def dump_eplased_time_log(self) -> None:
+    def dump_elapsed_time_log(self) -> None:
         report({
             f"time.{tag}": time / n
             for tag, (n, time) in self.elapsed_time_log.items()

--- a/test/entrypoint/test_evaluate.py
+++ b/test/entrypoint/test_evaluate.py
@@ -99,6 +99,7 @@ class TestEvaluateSynthesizer(unittest.TestCase):
         results.results[0].time = 0.0
         results.results[1].time = 0.0
         results.results[2].time = 0.0
+        results.results.sort(key=lambda x: x.query)
         self.assertEqual(
             Result("query0", {"ground_truth": ["c0", "c1", "c4"]},
                    ["c0", "c1", "c2"],

--- a/test/entrypoint/test_evaluate.py
+++ b/test/entrypoint/test_evaluate.py
@@ -6,7 +6,7 @@ import torch
 from mlprogram.entrypoint import evaluate
 from mlprogram.utils.data import ListDataset
 from mlprogram.metrics import Accuracy, Bleu
-from mlprogram.entrypoint.evaluate import evaluate_synthesizer, Result
+from mlprogram.entrypoint.evaluate import EvaluateSynthesizer, Result
 from mlprogram.synthesizers import Result as DecoderResult
 
 
@@ -53,8 +53,8 @@ class TestEvaluateSynthesizer(unittest.TestCase):
             "input": ["query0", "query1", "query2"],
             "ground_truth": ["c0", "c1", "c4"]
         }])
-        results = evaluate_synthesizer(dataset, synthesize,
-                                       metrics={"accuracy": accuracy})
+        results = EvaluateSynthesizer(dataset, synthesize,
+                                      metrics={"accuracy": accuracy})()
 
         self.assertEqual(
             results.metrics,
@@ -88,9 +88,9 @@ class TestEvaluateSynthesizer(unittest.TestCase):
             "input": ["query0", "query1", "query2"],
             "ground_truth": ["c0", "c1", "c4"]
         }])
-        results = evaluate_synthesizer(dataset, synthesize,
-                                       metrics={"accuracy": accuracy},
-                                       n_process=2)
+        results = EvaluateSynthesizer(dataset, synthesize,
+                                      metrics={"accuracy": accuracy},
+                                      n_process=2)()
 
         self.assertEqual(
             results.metrics,

--- a/test/entrypoint/test_train.py
+++ b/test/entrypoint/test_train.py
@@ -196,7 +196,7 @@ class TestTrainSupervised(unittest.TestCase):
                                                          kwargs["target"]),
                              MockEvaluate("key"), "key",
                              self.collate, 1, Iteration(2),
-                             interval=Iteration(1))
+                             evaluation_interval=Iteration(1))
             self.assertTrue(os.path.exists(
                 os.path.join(ws, "snapshot_iter_2")))
             self.assertTrue(os.path.exists(os.path.join(ws, "log")))
@@ -226,7 +226,7 @@ class TestTrainSupervised(unittest.TestCase):
                                                          kwargs["target"]),
                              MockEvaluate("key"), "key",
                              self.collate, 1, Iteration(2),
-                             interval=Iteration(1))
+                             evaluation_interval=Iteration(1))
             self.assertTrue(os.path.exists(
                 os.path.join(ws, "snapshot_iter_2")))
             self.assertTrue(os.path.exists(os.path.join(ws, "log")))

--- a/test/entrypoint/test_train.py
+++ b/test/entrypoint/test_train.py
@@ -93,14 +93,14 @@ class TestTrainSupervised(unittest.TestCase):
             with open(os.path.join(ws, "log")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
             self.assertTrue(os.path.exists(os.path.join(output, "model.pt")))
             self.assertTrue(
@@ -125,14 +125,14 @@ class TestTrainSupervised(unittest.TestCase):
             with open(os.path.join(ws, "log")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(0, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(0, len(os.listdir(os.path.join(output, "model"))))
             self.assertTrue(os.path.exists(os.path.join(output, "model.pt")))
             self.assertTrue(
@@ -203,14 +203,14 @@ class TestTrainSupervised(unittest.TestCase):
             with open(os.path.join(ws, "log")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
 
     def test_iterable_dataset(self):
@@ -233,14 +233,14 @@ class TestTrainSupervised(unittest.TestCase):
             with open(os.path.join(ws, "log")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
 
 
@@ -295,14 +295,14 @@ class TestTrainREINFORCE(unittest.TestCase):
             with open(os.path.join(ws, "log")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
-            self.assertEqual(2, len(log))
+            self.assertEqual(1, len(log))
             self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
             self.assertTrue(os.path.exists(os.path.join(output, "model.pt")))
             self.assertTrue(os.path.exists(

--- a/test/entrypoint/test_train.py
+++ b/test/entrypoint/test_train.py
@@ -94,14 +94,46 @@ class TestTrainSupervised(unittest.TestCase):
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(ws, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(output, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
+            self.assertTrue(os.path.exists(os.path.join(output, "model.pt")))
+            self.assertTrue(
+                os.path.exists(os.path.join(output, "optimizer.pt")))
+
+    def test_skip_evaluation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = os.path.join(tmpdir, "ws")
+            output = os.path.join(tmpdir, "out")
+            model = self.prepare_model()
+            train_supervised(ws, output,
+                             self.prepare_dataset(),
+                             model,
+                             self.prepare_optimizer(model),
+                             lambda kwargs: nn.MSELoss()(kwargs["value"],
+                                                         kwargs["target"]),
+                             None, "key",
+                             self.collate, 1, Epoch(2))
+            self.assertTrue(os.path.exists(
+                os.path.join(ws, "snapshot_iter_6")))
+            self.assertTrue(os.path.exists(os.path.join(ws, "log")))
+            with open(os.path.join(ws, "log")) as file:
+                log = json.load(file)
+            self.assertTrue(isinstance(log, list))
+            self.assertEqual(2, len(log))
+            self.assertEqual(0, len(os.listdir(os.path.join(ws, "model"))))
+
+            self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
+            with open(os.path.join(output, "log.json")) as file:
+                log = json.load(file)
+            self.assertTrue(isinstance(log, list))
+            self.assertEqual(2, len(log))
+            self.assertEqual(0, len(os.listdir(os.path.join(output, "model"))))
             self.assertTrue(os.path.exists(os.path.join(output, "model.pt")))
             self.assertTrue(
                 os.path.exists(os.path.join(output, "optimizer.pt")))
@@ -172,14 +204,14 @@ class TestTrainSupervised(unittest.TestCase):
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(ws, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(output, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
 
     def test_iterable_dataset(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -202,14 +234,14 @@ class TestTrainSupervised(unittest.TestCase):
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(ws, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(output, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
 
 
 class TestTrainREINFORCE(unittest.TestCase):
@@ -264,14 +296,14 @@ class TestTrainREINFORCE(unittest.TestCase):
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(ws, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(ws, "model"))))
 
             self.assertTrue(os.path.exists(os.path.join(output, "log.json")))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
             self.assertTrue(isinstance(log, list))
             self.assertEqual(2, len(log))
-            self.assertEqual(2, len(os.listdir(os.path.join(output, "model"))))
+            self.assertEqual(1, len(os.listdir(os.path.join(output, "model"))))
             self.assertTrue(os.path.exists(os.path.join(output, "model.pt")))
             self.assertTrue(os.path.exists(
                 os.path.join(output, "optimizer.pt")))

--- a/test/entrypoint/test_train.py
+++ b/test/entrypoint/test_train.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 from torch import optim
 
+from pytorch_pfn_extras.reporting import report
 from mlprogram.entrypoint.train import Epoch, Iteration
 from mlprogram.entrypoint import train_supervised, train_REINFORCE
 from mlprogram.utils.data import ListDataset
@@ -23,12 +24,8 @@ class MockSynthesizer:
             yield Result({"output": query["value"]}, 0, True, 1)
 
 
-def score(sample, output):
+def reward(sample, output):
     return sample["value"] == output["output"]
-
-
-def reward(score):
-    return score > 0.5
 
 
 class DummyModel(nn.Module):
@@ -39,6 +36,14 @@ class DummyModel(nn.Module):
     def forward(self, kwargs):
         kwargs["value"] = self.m(kwargs["value"])
         return kwargs
+
+
+class MockEvaluate(object):
+    def __init__(self, key):
+        self.key = key
+
+    def __call__(self):
+        report({self.key: 0.0})
 
 
 class TestTrainSupervised(unittest.TestCase):
@@ -80,8 +85,7 @@ class TestTrainSupervised(unittest.TestCase):
                              self.prepare_optimizer(model),
                              lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                          kwargs["target"]),
-                             lambda kwargs: nn.MSELoss()(kwargs["value"],
-                                                         kwargs["target"]),
+                             MockEvaluate("key"), "key",
                              self.collate, 1, Epoch(2))
             self.assertTrue(os.path.exists(
                 os.path.join(ws, "snapshot_iter_6")))
@@ -112,8 +116,7 @@ class TestTrainSupervised(unittest.TestCase):
                              model, self.prepare_optimizer(model),
                              lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                          kwargs["target"]),
-                             lambda kwargs: nn.MSELoss()(kwargs["value"],
-                                                         kwargs["target"]),
+                             MockEvaluate("key"), "key",
                              self.collate, 1, Epoch(2))
             self.assertTrue(os.path.exists(
                 os.path.join(ws, "snapshot_iter_6")))
@@ -129,8 +132,7 @@ class TestTrainSupervised(unittest.TestCase):
                              model, optimizer,
                              lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                          kwargs["target"]),
-                             lambda kwargs: nn.MSELoss()(kwargs["value"],
-                                                         kwargs["target"]),
+                             MockEvaluate("key"), "key",
                              self.collate, 1, Epoch(1))
             with open(os.path.join(output, "log.json")) as file:
                 log = json.load(file)
@@ -140,8 +142,7 @@ class TestTrainSupervised(unittest.TestCase):
                              model, optimizer,
                              lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                          kwargs["target"]),
-                             lambda kwargs: nn.MSELoss()(kwargs["value"],
-                                                         kwargs["target"]),
+                             MockEvaluate("key"), "key",
                              self.collate, 1, Epoch(2))
             self.assertTrue(os.path.exists(
                 os.path.join(ws, "snapshot_iter_6")))
@@ -161,8 +162,7 @@ class TestTrainSupervised(unittest.TestCase):
                              self.prepare_optimizer(model),
                              lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                          kwargs["target"]),
-                             lambda kwargs: nn.MSELoss()(kwargs["value"],
-                                                         kwargs["target"]),
+                             MockEvaluate("key"), "key",
                              self.collate, 1, Iteration(2),
                              interval=Iteration(1))
             self.assertTrue(os.path.exists(
@@ -192,8 +192,7 @@ class TestTrainSupervised(unittest.TestCase):
                              self.prepare_optimizer(model),
                              lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                          kwargs["target"]),
-                             lambda kwargs: nn.MSELoss()(kwargs["value"],
-                                                         kwargs["target"]),
+                             MockEvaluate("key"), "key",
                              self.collate, 1, Iteration(2),
                              interval=Iteration(1))
             self.assertTrue(os.path.exists(
@@ -253,7 +252,8 @@ class TestTrainREINFORCE(unittest.TestCase):
                             lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                         kwargs["target"]
                                                         ) * kwargs["reward"],
-                            score, reward,
+                            MockEvaluate("key"), "key",
+                            reward,
                             lambda x: x,
                             self.collate,
                             1, 1, Epoch(2))
@@ -295,7 +295,8 @@ class TestTrainREINFORCE(unittest.TestCase):
                             lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                         kwargs["target"]
                                                         ) * kwargs["reward"],
-                            score, reward,
+                            MockEvaluate("key"), "key",
+                            reward,
                             lambda x: x,
                             self.collate,
                             1, 1, Epoch(2),
@@ -321,9 +322,8 @@ class TestTrainREINFORCE(unittest.TestCase):
                             lambda kwargs: nn.MSELoss()(kwargs["value"],
                                                         kwargs["target"]
                                                         ) * kwargs["reward"],
-                            lambda sample, output:
-                                sample["value"] == output["output"],
-                            lambda score: score > 0.5,
+                            MockEvaluate("key"), "key",
+                            reward,
                             lambda x: x,
                             self.collate,
                             1, 1, Epoch(2),

--- a/test/test_csg_by_pbe_with_repl.py
+++ b/test/test_csg_by_pbe_with_repl.py
@@ -247,7 +247,8 @@ class TestCsgByPbeWithREPL(unittest.TestCase):
                 ])),
                 None, "score",
                 collate_fn,
-                1, Epoch(100), interval=Epoch(10)
+                1, Epoch(100), evaluation_interval=Epoch(10),
+                snapshot_interval=Epoch(100)
             )
         return encoder, train_dataset
 
@@ -338,7 +339,8 @@ class TestCsgByPbeWithREPL(unittest.TestCase):
                 RandomChoice(rng=np.random.RandomState(0)),
                 collate_fn,
                 1, 1,
-                Epoch(30), interval=Epoch(30),
+                Epoch(30), evaluation_interval=Epoch(30),
+                snapshot_interval=Epoch(30),
                 use_pretrained_model=True,
                 use_pretrained_optimizer=False)
 

--- a/test/test_csg_by_pbe_with_repl.py
+++ b/test/test_csg_by_pbe_with_repl.py
@@ -11,6 +11,7 @@ import torch
 import torch.optim as optim
 from mlprogram.entrypoint \
     import train_supervised, train_REINFORCE, evaluate as eval
+from mlprogram.entrypoint import EvaluateSynthesizer
 from mlprogram.entrypoint.train import Epoch
 from mlprogram.entrypoint.torch import Optimizer, Reshape
 from mlprogram.synthesizers \
@@ -25,7 +26,7 @@ from mlprogram.utils.data import Collate, CollateOptions
 from mlprogram.utils.transform \
     import EvaluateGroundTruth, RandomChoice
 import mlprogram.nn
-from mlprogram.nn.action_sequence import Loss, Accuracy
+from mlprogram.nn.action_sequence import Loss
 from mlprogram.nn import CNN2d, Apply, AggregatedLoss, MLP
 from mlprogram.nn.pbe_with_repl import Encoder
 import mlprogram.nn.action_sequence as a_s
@@ -186,16 +187,14 @@ class TestCsgByPbeWithREPL(unittest.TestCase):
             model = self.prepare_model(encoder)
             eval(
                 dir, tmpdir, dir,
-                dataset, dataset,
+                dataset,
                 model,
                 self.prepare_synthesizer(model, encoder, interpreter,
                                          rollout=False),
-                {},
-                "generation", top_n=[],
+                {}, top_n=[],
                 n_process=1
             )
-        results = torch.load(os.path.join(dir, "results.pt"))
-        return results["valid"]
+        return torch.load(os.path.join(dir, "result.pt"))
 
     def pretrain(self, output_dir):
         dataset = Dataset(2, 1, 2, 1, 45, reference=True, seed=1)
@@ -246,13 +245,9 @@ class TestCsgByPbeWithREPL(unittest.TestCase):
                          constants={"rhs": 1})),
                     ("pick", mlprogram.nn.Pick("action_sequence_loss"))
                 ])),
-                torch.nn.Sequential(OrderedDict([
-                    ("accuracy", Accuracy()),
-                    ("pick", mlprogram.nn.Pick("action_sequence_accuracy"))
-                ])),
+                None, "score",
                 collate_fn,
-                1, Epoch(100), interval=Epoch(10),
-                n_model=0
+                1, Epoch(100), interval=Epoch(10)
             )
         return encoder, train_dataset
 
@@ -330,14 +325,20 @@ class TestCsgByPbeWithREPL(unittest.TestCase):
                          constants={"rhs": 1})),
                     ("pick", mlprogram.nn.Pick("loss"))
                 ])),
-                metrics.TestCaseResult(interpreter, reference=True,
-                                       metric=metrics.Iou()),
-                Threshold(0.9, dtype="float"),
+                EvaluateSynthesizer(
+                    train_dataset,
+                    self.prepare_synthesizer(model, encoder, interpreter,
+                                             rollout=False),
+                    {}, top_n=[]),
+                "generation_rate",
+                metrics.transform(
+                    metrics.TestCaseResult(interpreter, reference=True,
+                                           metric=metrics.Iou()),
+                    Threshold(0.9, dtype="float")),
                 RandomChoice(rng=np.random.RandomState(0)),
                 collate_fn,
                 1, 1,
-                Epoch(30), interval=Epoch(10),
-                n_model=1,
+                Epoch(30), interval=Epoch(30),
                 use_pretrained_model=True,
                 use_pretrained_optimizer=False)
 
@@ -348,8 +349,8 @@ class TestCsgByPbeWithREPL(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             encoder, dataset = self.pretrain(tmpdir)
             self.reinforce(dataset, encoder, tmpdir)
-            results = self.evaluate(dataset, encoder, tmpdir)
-        self.assertLessEqual(0.9, results.generation_rate)
+            result = self.evaluate(dataset, encoder, tmpdir)
+        self.assertLessEqual(0.9, result.generation_rate)
 
 
 if __name__ == "__main__":

--- a/test/test_nl2code.py
+++ b/test/test_nl2code.py
@@ -159,7 +159,8 @@ class TestNL2Code(unittest.TestCase):
                 ),
                 "accuracy@5",
                 lambda x: collate(transform(x)),
-                1, Epoch(100), interval=Epoch(100)
+                1, Epoch(100), evaluation_interval=Epoch(100),
+                snapshot_interval=Epoch(100)
             )
         return qencoder, aencoder
 

--- a/test/test_nl2code.py
+++ b/test/test_nl2code.py
@@ -13,6 +13,7 @@ import torch.optim as optim
 from torchnlp.encoders import LabelEncoder
 import mlprogram.nn
 from mlprogram.entrypoint import evaluate as eval, train_supervised
+from mlprogram.entrypoint import EvaluateSynthesizer
 from mlprogram.entrypoint.train import Epoch
 from mlprogram.entrypoint.torch import Optimizer
 from mlprogram.actions import AstToActionSequence
@@ -112,15 +113,13 @@ class TestNL2Code(unittest.TestCase):
             model = self.prepare_model(qencoder, aencoder)
             eval(
                 dir, tmpdir, dir,
-                test_dataset, test_dataset,
-                model,
+                test_dataset, model,
                 self.prepare_synthesizer(model, qencoder, aencoder),
                 {"accuracy": Accuracy()},
-                (5, "accuracy"), top_n=[5],
+                top_n=[5],
                 n_process=1
             )
-        results = torch.load(os.path.join(dir, "results.pt"))
-        return results["valid"]
+        return torch.load(os.path.join(dir, "result.pt"))
 
     def train(self, output_dir):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -152,10 +151,15 @@ class TestNL2Code(unittest.TestCase):
             train_supervised(
                 tmpdir, output_dir,
                 train_dataset, model, optimizer,
-                loss_fn, lambda args: -loss_fn(args),
+                loss_fn,
+                EvaluateSynthesizer(
+                    test_dataset,
+                    self.prepare_synthesizer(model, qencoder, aencoder),
+                    {"accuracy": Accuracy()}, top_n=[5]
+                ),
+                "accuracy@5",
                 lambda x: collate(transform(x)),
-                1, Epoch(100), interval=Epoch(10),
-                n_model=1
+                1, Epoch(100), interval=Epoch(100)
             )
         return qencoder, aencoder
 

--- a/test/test_treegen.py
+++ b/test/test_treegen.py
@@ -16,6 +16,7 @@ from torchnlp.encoders import LabelEncoder
 
 import mlprogram.nn
 from mlprogram.entrypoint import evaluate as eval, train_supervised
+from mlprogram.entrypoint import EvaluateSynthesizer
 from mlprogram.entrypoint.train import Epoch
 from mlprogram.entrypoint.torch import Optimizer
 from mlprogram.actions import AstToActionSequence
@@ -128,16 +129,15 @@ class TestTreeGen(unittest.TestCase):
             model = self.prepare_model(qencoder, cencoder, aencoder)
             eval(
                 dir, tmpdir, dir,
-                test_dataset, test_dataset,
+                test_dataset,
                 model,
                 self.prepare_synthesizer(
                     model, qencoder, cencoder, aencoder),
                 {"accuracy": Accuracy()},
-                (5, "accuracy"), top_n=[5],
+                top_n=[5],
                 n_process=1
             )
-        results = torch.load(os.path.join(dir, "results.pt"))
-        return results["valid"]
+        return torch.load(os.path.join(dir, "result.pt"))
 
     def train(self, output_dir):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -167,10 +167,16 @@ class TestTreeGen(unittest.TestCase):
             train_supervised(
                 tmpdir, output_dir, train_dataset,
                 model, self.prepare_optimizer(model),
-                loss_fn, lambda args: -loss_fn(args),
+                loss_fn,
+                EvaluateSynthesizer(
+                    test_dataset,
+                    self.prepare_synthesizer(model, *encoder),
+                    {"accuracy": Accuracy()},
+                    top_n=[5]
+                ),
+                "accuracy@5",
                 lambda x: collate(transform(x)),
-                1, Epoch(100), interval=Epoch(10),
-                n_model=1
+                1, Epoch(100), interval=Epoch(100)
             )
         return encoder
 

--- a/test/test_treegen.py
+++ b/test/test_treegen.py
@@ -176,7 +176,8 @@ class TestTreeGen(unittest.TestCase):
                 ),
                 "accuracy@5",
                 lambda x: collate(transform(x)),
-                1, Epoch(100), interval=Epoch(100)
+                1, Epoch(100), evaluation_interval=Epoch(100),
+                snapshot_interval=Epoch(100)
             )
         return encoder
 

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -33,7 +33,11 @@ def modify_config_for_test(configs: Any, tmpdir: str) -> Any:
                         "type": "mlprogram.entrypoint.train.Iteration",
                         "n": 2
                     }
-                    value["interval"] = {
+                    value["evaluation_interval"] = {
+                        "type": "mlprogram.entrypoint.train.Iteration",
+                        "n": 2
+                    }
+                    value["snapshot_interval"] = {
                         "type": "mlprogram.entrypoint.train.Iteration",
                         "n": 2
                     }
@@ -81,7 +85,11 @@ def modify_config_for_profile(configs: Any, tmpdir: str) -> Any:
                         "type": "mlprogram.entrypoint.train.Iteration",
                         "n": 2
                     }
-                    value["interval"] = {
+                    value["evaluation_interval"] = {
+                        "type": "mlprogram.entrypoint.train.Iteration",
+                        "n": 2
+                    }
+                    value["snapshot_interval"] = {
                         "type": "mlprogram.entrypoint.train.Iteration",
                         "n": 2
                     }

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -21,7 +21,7 @@ def modify_config_for_test(configs: Any, tmpdir: str) -> Any:
     if isinstance(configs, dict):
         out = {}
         for key, value in configs.items():
-            if key == "device":
+            if key == "device" and isinstance(value, dict):
                 value["type_str"] = "cpu"
             elif key == "output_dir":
                 value = f"{tmpdir}/output"
@@ -39,6 +39,10 @@ def modify_config_for_test(configs: Any, tmpdir: str) -> Any:
                     }
                     value["workspace_dir"] = \
                         f"{tmpdir}/workspace.{random.randint(0, 100)}"
+                elif value["type"] in set([
+                    "mlprogram.entrypoint.EvaluateSynthesizer"
+                ]):
+                    value["n_samples"] = 1
                 elif value["type"] in set(["mlprogram.entrypoint.evaluate"]):
                     value["n_samples"] = 1
                     value["workspace_dir"] = \
@@ -52,11 +56,9 @@ def modify_config_for_test(configs: Any, tmpdir: str) -> Any:
                     "mlprogram.synthesizers.SynthesizerWithTimeout"
                 ]):
                     value["timeout_sec"] = 0.5
-                value = {k: modify_config_for_test(v, tmpdir)
-                         for k, v in value.items()}
+                value = modify_config_for_test(value, tmpdir)
             elif isinstance(value, dict):
-                value = {k: modify_config_for_test(v, tmpdir)
-                         for k, v in value.items()}
+                value = modify_config_for_test(value, tmpdir)
             elif isinstance(value, list):
                 value = [modify_config_for_test(x, tmpdir) for x in value]
             else:
@@ -94,15 +96,13 @@ def modify_config_for_profile(configs: Any, tmpdir: str) -> Any:
                     if "n_process" in value:
                         # This prevent "Too many open files" error
                         value["n_process"] = 1
-                value = {k: modify_config_for_test(v, tmpdir)
-                         for k, v in value.items()}
+                value = modify_config_for_profile(value, tmpdir)
             elif isinstance(value, dict):
-                value = {k: modify_config_for_test(v, tmpdir)
-                         for k, v in value.items()}
+                value = modify_config_for_profile(value, tmpdir)
             elif isinstance(value, list):
-                value = [modify_config_for_test(x, tmpdir) for x in value]
+                value = [modify_config_for_profile(x, tmpdir) for x in value]
             else:
-                value = modify_config_for_test(value, tmpdir)
+                value = modify_config_for_profile(value, tmpdir)
             out[key] = value
         return out
     else:


### PR DESCRIPTION
close #43

---

* [x] Add an extension to invoke evaluation during training
* [x] ~~Switch devices between training and evaluation~~
* [x] ~~Dump test score during training~~
* [x] ~~Add components of config to reduce the test dataset~~
    * Reduce the number of samples
    * Add a timeout
* [x] Print logs more frequently
* [x] Show progress of multi-process evaluation
* [x] Set interval of snapshot saving

### TODO (testing)

* [x] Check performance with (NL2Code, Hearthstone) => bleu@1 0.803
* [x] Check performance with (TreeGen, Hearthstone) => bleu@1 0.687
* [x] Check performance with (PbeWithoutREPL, CSG_small) => 26/30 examples generated
* [x] Check performance with (PbeWithREPL, CSG_small) => 18/30 examples generated